### PR TITLE
Ingest schema

### DIFF
--- a/WonkaSystem/WonkaBre/App.config
+++ b/WonkaSystem/WonkaBre/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <configSections>
+        <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
+    </configSections>
+</configuration>

--- a/WonkaSystem/WonkaBre/Import/WonkaBreImportFactory.cs
+++ b/WonkaSystem/WonkaBre/Import/WonkaBreImportFactory.cs
@@ -22,6 +22,7 @@ namespace WonkaBre.Import
         #region CONSTANTS
 
         public const int CONST_DEFAULT_GROUP_ID = 1;
+        public const int CONST_SEC_LEVEL_READ   = 1;
 
         public const string CONST_SAMPLE_RULE_FORMAT_MAIN_BODY =
 @"<?xml version=""1.0""?>
@@ -266,12 +267,6 @@ namespace WonkaBre.Import
                     string sTmpColName = TmpCol.colName;
                     var    Props       = TmpCol.props;
 
-                    /*
-                    var propertyInfo = entity.Entity.GetType().GetProperty(propertyName);
-                    var propertyType = propertyInfo.PropertyType;                    
-                    string sTmpColName = poReader.GetName(i);
-                    */
-
                     WonkaRefAttr TmpWonkaAttr = new WonkaRefAttr();
 
                     TmpWonkaAttr.AttrId   = GenerateNewAttrId();
@@ -314,6 +309,13 @@ namespace WonkaBre.Import
                 NewImportGroup.ProductTabName = psDatabaseTable;
                 NewImportSource.AddGroup(NewImportGroup);
 
+                WonkaRefSource GuestSource = new WonkaRefSource();
+
+                GuestSource.SourceId   = 1;
+                GuestSource.SourceName = "Guest";
+                GuestSource.Status     = "Active";
+                NewImportSource.AddSource(GuestSource);
+
                 foreach (WonkaRefAttr TempAttr in NewImportSource.GetAttrCache())
                 {
                     WonkaRefField NewImportField = new WonkaRefField();
@@ -324,8 +326,15 @@ namespace WonkaBre.Import
                     NewImportField.GroupId     = CONST_DEFAULT_GROUP_ID;
                     NewImportField.DisplayName = TempAttr.AttrName;
                     NewImportField.AttrIds.Add(TempAttr.AttrId);
-
                     NewImportSource.AddField(NewImportField);
+
+                    WonkaRefSourceField NewImportSrcFld = new WonkaRefSourceField();
+
+                    NewImportSrcFld.SourceFieldId = 10000 + NewImportField.FieldId;
+                    NewImportSrcFld.SourceId      = 1;
+                    NewImportSrcFld.FieldId       = NewImportField.FieldId;
+                    NewImportSrcFld.SecurityLevel = CONST_SEC_LEVEL_READ;
+                    NewImportSource.AddSourceField(NewImportSrcFld);
                 }
             }
             else

--- a/WonkaSystem/WonkaBre/Import/WonkaBreImportFactory.cs
+++ b/WonkaSystem/WonkaBre/Import/WonkaBreImportFactory.cs
@@ -305,6 +305,28 @@ namespace WonkaBre.Import
 
                 if (NewImportSource.GetAttrCache().Count <= 0)
                     throw new WonkaBreException(0, 0, "ERROR!  Could not import the schema because the Reader's field count was zero.");
+
+                WonkaRefGroup NewImportGroup = new WonkaRefGroup();
+
+                NewImportGroup.GroupId        = CONST_DEFAULT_GROUP_ID;
+                NewImportGroup.GroupName      = psDatabaseTable;
+                NewImportGroup.KeyTabCols     = KeyColNames;
+                NewImportGroup.ProductTabName = psDatabaseTable;
+                NewImportSource.AddGroup(NewImportGroup);
+
+                foreach (WonkaRefAttr TempAttr in NewImportSource.GetAttrCache())
+                {
+                    WonkaRefField NewImportField = new WonkaRefField();
+
+                    NewImportField.FieldId     = TempAttr.FieldId;
+                    NewImportField.FieldName   = TempAttr.AttrName;
+                    NewImportField.Description = TempAttr.Description;
+                    NewImportField.GroupId     = CONST_DEFAULT_GROUP_ID;
+                    NewImportField.DisplayName = TempAttr.AttrName;
+                    NewImportField.AttrIds.Add(TempAttr.AttrId);
+
+                    NewImportSource.AddField(NewImportField);
+                }
             }
             else
                 throw new WonkaBreException(0, 0, "ERROR!  Could not import the schema for the database table.");

--- a/WonkaSystem/WonkaBre/Import/WonkaBreImportFactory.cs
+++ b/WonkaSystem/WonkaBre/Import/WonkaBreImportFactory.cs
@@ -139,7 +139,66 @@ namespace WonkaBre.Import
         {
             StringBuilder sbRulesBody = new StringBuilder();
 
-            // NOTE: Do work here
+            if (piMetadata != null)
+            {
+                var AttrCache = piMetadata.GetAttrCache();
+
+                if (AttrCache.Count >= 2)
+                {
+                    string sChildBranch1 = "";
+                    string sChildBranch2 = "";
+
+                    var AttrNumCache = AttrCache.Where(x => x.IsDecimal || x.IsNumeric);
+                    var AttrStrCache = AttrCache.Where(x => !x.IsDecimal && !x.IsNumeric);
+
+                    if (AttrNumCache.Count() >= 2)
+                    {
+                        sChildBranch1 =
+                            String.Format(CONST_SAMPLE_RULE_FORMAT_SUB_BODY1,
+                                          AttrNumCache.ElementAt(0).AttrName,
+                                          AttrNumCache.ElementAt(1).AttrName);
+                    }
+                    else if (AttrNumCache.Count() == 1)
+                    {
+                        sChildBranch1 =
+                            String.Format(CONST_SAMPLE_RULE_FORMAT_SUB_BODY1,
+                                          AttrNumCache.ElementAt(0).AttrName,
+                                          AttrNumCache.ElementAt(0).AttrName);
+                    }
+
+                    if (AttrStrCache.Count() >= 4)
+                    {
+                        sChildBranch2 =
+                            String.Format(CONST_SAMPLE_RULE_FORMAT_SUB_BODY2,
+                                          AttrStrCache.ElementAt(2).AttrName,
+                                          AttrStrCache.ElementAt(3).AttrName);
+                    }
+                    else if (AttrStrCache.Count() == 3)
+                    {
+                        sChildBranch2 =
+                            String.Format(CONST_SAMPLE_RULE_FORMAT_SUB_BODY2,
+                                          AttrStrCache.ElementAt(1).AttrName,
+                                          AttrStrCache.ElementAt(2).AttrName);
+                    }
+                    else
+                    {
+                        sChildBranch2 =
+                            String.Format(CONST_SAMPLE_RULE_FORMAT_SUB_BODY2,
+                                          AttrStrCache.ElementAt(0).AttrName,
+                                          AttrStrCache.ElementAt(1).AttrName);
+                    }
+
+                    string sParentBranch = 
+                        String.Format(CONST_SAMPLE_RULE_FORMAT_MAIN_BODY, 
+                                      AttrCache[0].AttrName, 
+                                      AttrCache[1].AttrName,
+                                      sChildBranch1,
+                                      sChildBranch2);
+
+                    sbRulesBody.Append(sParentBranch);
+
+                }
+            }
 
             if (!String.IsNullOrEmpty(psRulesOutputFile))
             {

--- a/WonkaSystem/WonkaBre/Import/WonkaBreImportFactory.cs
+++ b/WonkaSystem/WonkaBre/Import/WonkaBreImportFactory.cs
@@ -1,0 +1,182 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Entity.Core.Objects;
+using System.Data.Entity.Core.Metadata.Edm;
+using System.Linq;
+
+using WonkaRef;
+
+namespace WonkaBre.Import
+{
+    /// <summary>
+    /// 
+    /// This extensions class provides additional functionality for the Rules Engine, including the ability to
+    /// import a schema from a database table and designate that as an IMetadataRetrievable instance.
+    /// 
+    /// </summary>
+    public class WonkaBreImportFactory
+    {
+        #region CONSTANTS
+
+        public const int CONST_DEFAULT_GROUP_ID = 1;
+
+        #endregion
+
+        private static object mLock = new object();
+        private static object mIdLock = new object();
+
+        private static int mGenAttrId = 1;
+
+        private static WonkaBreImportFactory mInstance = null;
+
+        Dictionary<string, IMetadataRetrievable> moCachedImports;
+
+        private WonkaBreImportFactory()
+        {
+            moCachedImports = new Dictionary<string, IMetadataRetrievable>();
+        }
+
+        static private WonkaBreImportFactory CreateInstance()
+        {
+            lock (mLock)
+            {
+                if (mInstance == null)
+                    mInstance = new WonkaBreImportFactory();
+
+                return mInstance;
+            }
+        }
+
+        static public WonkaBreImportFactory GetInstance()
+        {
+            lock (mLock)
+            {
+                if (mInstance == null)
+                    mInstance = CreateInstance();
+
+                return mInstance;
+            }
+        }
+
+        #region Instance Methods
+
+        private void CacheImport(string psDatabaseTable, IMetadataRetrievable poSource)
+        {
+            if (!String.IsNullOrEmpty(psDatabaseTable) && (poSource != null))
+                moCachedImports[psDatabaseTable] = poSource;
+            else
+                throw new WonkaBreException(0, 0, "ERROR!  Could not cache the schema for the database table.");
+        }
+
+        private int GenerateNewAttrId()
+        {
+            lock (mIdLock)
+            {
+                return mGenAttrId++;
+            }
+        }
+
+        public IMetadataRetrievable ImportSource(string psDatabaseTable, ObjectContext poDbContext)
+        {
+            WonkaBreImportSource NewImportSource = new WonkaBreImportSource();
+
+            if (!String.IsNullOrEmpty(psDatabaseTable) && (poDbContext != null))
+            {
+                if (moCachedImports.ContainsKey(psDatabaseTable))
+                    return moCachedImports[psDatabaseTable];
+
+                var columns =
+                    from meta in poDbContext.MetadataWorkspace.GetItems(DataSpace.CSpace).Where(m => m.BuiltInTypeKind == BuiltInTypeKind.EntityType)
+                    from p in (meta as EntityType).Properties.Where(p => p.DeclaringType.Name == psDatabaseTable)
+                    select new
+                    {
+                        colName = p.Name,
+                        colType = p.TypeUsage.EdmType,
+                        maxLength = p.MaxLength
+                    };
+
+                foreach (var TmpCol in columns)
+                {
+                    string sTmpColName = TmpCol.colName;
+
+                    /*
+                    var propertyInfo = entity.Entity.GetType().GetProperty(propertyName);
+                    var propertyType = propertyInfo.PropertyType;                    
+                    string sTmpColName = poReader.GetName(i);
+                    */
+
+                    WonkaRefAttr TmpWonkaAttr = new WonkaRefAttr();
+
+                    TmpWonkaAttr.AttrId = GenerateNewAttrId();
+                    TmpWonkaAttr.AttrName = sTmpColName;
+
+                    TmpWonkaAttr.IsNumeric = IsTypeNumeric(TmpCol.colType);
+                    TmpWonkaAttr.IsDecimal = IsTypeDecimal(TmpCol.colType);
+                    TmpWonkaAttr.MaxLength = (TmpCol.maxLength != null) ? (int)TmpCol.maxLength : 0;
+
+                    TmpWonkaAttr.FieldId = TmpWonkaAttr.AttrId + 1000;
+                    TmpWonkaAttr.GroupId = CONST_DEFAULT_GROUP_ID;
+                    TmpWonkaAttr.IsAudited = true;
+
+                    // TmpWonkaAttr.IsKey = ?
+
+                    NewImportSource.AddAttribute(TmpWonkaAttr);
+                }
+
+                if (NewImportSource.GetAttrCache().Count <= 0)
+                    throw new WonkaBreException(0, 0, "ERROR!  Could not import the schema because the Reader's field count was zero.");
+            }
+            else
+                throw new WonkaBreException(0, 0, "ERROR!  Could not import the schema for the database table.");
+
+            PopulateDefaults();
+
+            return NewImportSource;
+        }
+
+        public void PopulateDefaults()
+        {
+            // NOTE: Do work here
+        }
+
+        public static bool IsTypeDecimal(EdmType edmType)
+        {
+            switch (edmType.Name)
+            {
+                case "Float":
+                case "Double":
+                case "Decimal":
+                    return true;
+
+                default:
+                    return false;
+            }
+        }
+
+        public static bool IsTypeNumeric(EdmType edmType)
+        {
+            switch (edmType.Name)
+            {
+                case "String":
+                case "Guid":
+                case "DateTime":
+                    return false;
+
+                case "Int32":
+                    return true;
+
+                case "Single":
+                case "Double":
+                    return true;
+
+                default:
+                    return false;
+            }
+        }
+
+        #endregion
+
+    }
+}
+

--- a/WonkaSystem/WonkaBre/Import/WonkaBreImportFactory.cs
+++ b/WonkaSystem/WonkaBre/Import/WonkaBreImportFactory.cs
@@ -77,6 +77,14 @@ namespace WonkaBre.Import
             }
         }
 
+        public IMetadataRetrievable ImportSource(string psDatabaseTable, System.Data.Entity.DbContext poDbContext)
+        {
+            var adapter       = (System.Data.Entity.Infrastructure.IObjectContextAdapter) poDbContext;
+            var objectContext = adapter.ObjectContext;
+
+            return ImportSource(psDatabaseTable, objectContext);
+        }
+
         public IMetadataRetrievable ImportSource(string psDatabaseTable, ObjectContext poDbContext)
         {
             WonkaBreImportSource NewImportSource = new WonkaBreImportSource();

--- a/WonkaSystem/WonkaBre/Import/WonkaBreImportSource.cs
+++ b/WonkaSystem/WonkaBre/Import/WonkaBreImportSource.cs
@@ -16,6 +16,16 @@ namespace WonkaBre.Import
             AttrCollection.Add(poNewAttribute);
         }
 
+        public void AddGroup(WonkaRefGroup poNewGroup)
+        {
+            GroupCollection.Add(poNewGroup);
+        }
+
+        public void AddField(WonkaRefField poNewField)
+        {
+            FieldCollection.Add(poNewField);
+        }
+
         #region Required Interface Methods
 
         #region Standard Metadata Cache (Minimum Set)
@@ -99,6 +109,10 @@ namespace WonkaBre.Import
         #region Properties
 
         private List<WonkaRefAttr> AttrCollection;
+
+        private List<WonkaRefGroup> GroupCollection;
+
+        private List<WonkaRefField> FieldCollection;
 
         #endregion
     }

--- a/WonkaSystem/WonkaBre/Import/WonkaBreImportSource.cs
+++ b/WonkaSystem/WonkaBre/Import/WonkaBreImportSource.cs
@@ -8,7 +8,11 @@ namespace WonkaBre.Import
     {
         public WonkaBreImportSource()
         {
-            AttrCollection = new List<WonkaRefAttr>();
+            AttrCollection   = new List<WonkaRefAttr>();
+            FieldCollection  = new List<WonkaRefField>();
+            GroupCollection  = new List<WonkaRefGroup>();
+            SourceCollection = new List<WonkaRefSource>();
+            SrcFldCollection = new List<WonkaRefSourceField>();
         }
 
         public void AddAttribute(WonkaRefAttr poNewAttribute)
@@ -24,6 +28,16 @@ namespace WonkaBre.Import
         public void AddField(WonkaRefField poNewField)
         {
             FieldCollection.Add(poNewField);
+        }
+
+        public void AddSource(WonkaRefSource poNewSource)
+        {
+            SourceCollection.Add(poNewSource);
+        }
+
+        public void AddSourceField(WonkaRefSourceField poNewSrcField)
+        {
+            SrcFldCollection.Add(poNewSrcField);
         }
 
         #region Required Interface Methods
@@ -46,38 +60,22 @@ namespace WonkaBre.Import
 
         public List<WonkaRefField> GetFieldCache()
         {
-            List<WonkaRefField> FieldCache = new List<WonkaRefField>();
-
-            // NOTE: To be implemented
-
-            return FieldCache;
+            return FieldCollection;
         }
 
         public List<WonkaRefGroup> GetGroupCache()
         {
-            List<WonkaRefGroup> GroupCache = new List<WonkaRefGroup>();
-
-            // NOTE: To be implemented
-
-            return GroupCache;
+            return GroupCollection;
         }
 
         public List<WonkaRefSource> GetSourceCache()
         {
-            List<WonkaRefSource> SourceCache = new List<WonkaRefSource>();
-
-            // NOTE: To be implemented
-
-            return SourceCache;
+            return SourceCollection;
         }
 
         public List<WonkaRefSourceField> GetSourceFieldCache()
         {
-            List<WonkaRefSourceField> SourceFieldCache = new List<WonkaRefSourceField>();
-
-            // NOTE: To be implemented
-
-            return SourceFieldCache;
+            return SrcFldCollection;
         }
 
         public List<WonkaRefStandard> GetStandardCache()
@@ -113,6 +111,10 @@ namespace WonkaBre.Import
         private List<WonkaRefGroup> GroupCollection;
 
         private List<WonkaRefField> FieldCollection;
+
+        private List<WonkaRefSource> SourceCollection;
+
+        private List<WonkaRefSourceField> SrcFldCollection;
 
         #endregion
     }

--- a/WonkaSystem/WonkaBre/Import/WonkaBreImportSource.cs
+++ b/WonkaSystem/WonkaBre/Import/WonkaBreImportSource.cs
@@ -1,0 +1,105 @@
+﻿using System.Collections.Generic;
+
+using WonkaRef;
+
+namespace WonkaBre.Import
+{
+    public class WonkaBreImportSource : IMetadataRetrievable
+    {
+        public WonkaBreImportSource()
+        {
+            AttrCollection = new List<WonkaRefAttr>();
+        }
+
+        public void AddAttribute(WonkaRefAttr poNewAttribute)
+        {
+            AttrCollection.Add(poNewAttribute);
+        }
+
+        #region Required Interface Methods
+
+        #region Standard Metadata Cache (Minimum Set)
+
+        public List<WonkaRefAttr> GetAttrCache()
+        {
+            return AttrCollection;
+        }
+
+        public List<WonkaRefCurrency> GetCurrencyCache()
+        {
+            List<WonkaRefCurrency> CurrencyCache = new List<WonkaRefCurrency>();
+
+            // NOTE: Not necessary
+
+            return CurrencyCache;
+        }
+
+        public List<WonkaRefField> GetFieldCache()
+        {
+            List<WonkaRefField> FieldCache = new List<WonkaRefField>();
+
+            // NOTE: To be implemented
+
+            return FieldCache;
+        }
+
+        public List<WonkaRefGroup> GetGroupCache()
+        {
+            List<WonkaRefGroup> GroupCache = new List<WonkaRefGroup>();
+
+            // NOTE: To be implemented
+
+            return GroupCache;
+        }
+
+        public List<WonkaRefSource> GetSourceCache()
+        {
+            List<WonkaRefSource> SourceCache = new List<WonkaRefSource>();
+
+            // NOTE: To be implemented
+
+            return SourceCache;
+        }
+
+        public List<WonkaRefSourceField> GetSourceFieldCache()
+        {
+            List<WonkaRefSourceField> SourceFieldCache = new List<WonkaRefSourceField>();
+
+            // NOTE: To be implemented
+
+            return SourceFieldCache;
+        }
+
+        public List<WonkaRefStandard> GetStandardCache()
+        {
+            List<WonkaRefStandard> StandardCache = new List<WonkaRefStandard>();
+
+            // NOTE: To be implemented
+
+            return StandardCache;
+        }
+
+        #endregion
+
+        #region Extended Metadata Cache
+
+        public List<WonkaRefAttrCollection> GetAttrCollectionCache()
+        {
+            List<WonkaRefAttrCollection> AttrCollCache = new List<WonkaRefAttrCollection>();
+
+            // NOTE: To be implemented
+
+            return AttrCollCache;
+        }
+
+        #endregion
+
+        #endregion
+
+        #region Properties
+
+        private List<WonkaRefAttr> AttrCollection;
+
+        #endregion
+    }
+}

--- a/WonkaSystem/WonkaBre/WonkaBre.csproj
+++ b/WonkaSystem/WonkaBre/WonkaBre.csproj
@@ -38,6 +38,13 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
+    <Reference Include="EntityFramework">
+      <HintPath>..\packages\EntityFramework.6.2.0\lib\net45\EntityFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="EntityFramework.SqlServer">
+      <HintPath>..\packages\EntityFramework.6.2.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ComponentModel.DataAnnotations" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="WonkaBreEnumerations.cs" />
@@ -60,6 +67,8 @@
     <Compile Include="RuleTree\WonkaBreSource.cs" />
     <Compile Include="RuleTree\RuleTypes\ArithmeticRule.cs" />
     <Compile Include="RuleTree\RuleTypes\CustomOperatorRule.cs" />
+    <Compile Include="Import\WonkaBreImportSource.cs" />
+    <Compile Include="Import\WonkaBreImportFactory.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\WonkaPrd\WonkaPrd.csproj">
@@ -77,9 +86,12 @@
     <Folder Include="Readers\" />
     <Folder Include="Reporting\" />
     <Folder Include="Samples\" />
+    <Folder Include="Import\" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Samples\SimpleAccountCheck.xml" />
+    <None Include="App.config" />
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/WonkaSystem/WonkaBre/packages.config
+++ b/WonkaSystem/WonkaBre/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="EntityFramework" version="6.2.0" targetFramework="net452" />
+</packages>

--- a/WonkaSystem/WonkaRef/Extensions/WonkaRefDeserializeLocalSource.cs
+++ b/WonkaSystem/WonkaRef/Extensions/WonkaRefDeserializeLocalSource.cs
@@ -23,17 +23,19 @@ namespace WonkaRef.Extensions
 
         private XmlDocument       moXmlDoc = null;
 
-        public WonkaRefDeserializeLocalSource(FileInfo poMetadataConfigFile)
+        public WonkaRefDeserializeLocalSource(FileInfo poMetadataConfigFile) : this(File.ReadAllText(poMetadataConfigFile.FullName))
+        { }
+
+        public WonkaRefDeserializeLocalSource(string psMetadataConfigFileText)
         {
-            using (StreamReader MetadataReader = new StreamReader(poMetadataConfigFile.FullName))
+            msMetadataFileContents = psMetadataConfigFileText;
+            moMetadataXmlElement   = XElement.Parse(psMetadataConfigFileText);
+
+            using (StringReader MetadataReader = new StringReader(psMetadataConfigFileText))
             {
-                msMetadataFileContents = File.ReadAllText(poMetadataConfigFile.FullName);
-                moMetadataXmlElement   = XElement.Parse(msMetadataFileContents);
-
                 moXmlDoc = new XmlDocument();
-                moXmlDoc.Load(poMetadataConfigFile.FullName);
+                moXmlDoc.Load(MetadataReader);
             }
-
         }
 
         #region Required Interface Methods

--- a/WonkaSystem/WonkaRef/Extensions/WonkaRefDeserializeLocalSource.cs
+++ b/WonkaSystem/WonkaRef/Extensions/WonkaRefDeserializeLocalSource.cs
@@ -1,0 +1,153 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Xml;
+using System.Xml.Linq;
+using System.Xml.Serialization;
+
+using WonkaRef;
+
+namespace WonkaRef.Extensions
+{
+    public class WonkaRefDeserializeLocalSource : IMetadataRetrievable
+    {
+        private string            msMetadataFileContents = null;
+        private XElement          moMetadataXmlElement   = null;
+
+        private XmlDocument       moXmlDoc = null;
+
+        public WonkaRefDeserializeLocalSource(FileInfo poMetadataConfigFile)
+        {
+            using (StreamReader MetadataReader = new StreamReader(poMetadataConfigFile.FullName))
+            {
+                msMetadataFileContents = File.ReadAllText(poMetadataConfigFile.FullName);
+                moMetadataXmlElement   = XElement.Parse(msMetadataFileContents);
+
+                moXmlDoc = new XmlDocument();
+                moXmlDoc.Load(poMetadataConfigFile.FullName);
+            }
+
+        }
+
+        #region Required Interface Methods
+
+        #region Standard Metadata Cache (Minimum Set)
+
+        public List<WonkaRefAttr> GetAttrCache()
+        {
+            List<WonkaRefAttr> AttrCache      = new List<WonkaRefAttr>();
+            XmlSerializer      AttrSerializer = new XmlSerializer(typeof(WonkaRefAttr));
+
+            XmlNodeList AttrNodeList = moXmlDoc.GetElementsByTagName("Attr");
+            foreach (XmlNode AttrNode in AttrNodeList)
+            {
+                WonkaRefAttr TempAttr = (WonkaRefAttr) AttrSerializer.Deserialize(new StringReader(AttrNode.OuterXml));
+
+                AttrCache.Add(TempAttr);
+            }
+
+            return AttrCache;
+        }
+
+        public List<WonkaRefCurrency> GetCurrencyCache()
+        {
+            List<WonkaRefCurrency> CurrencyCache      = new List<WonkaRefCurrency>();
+            XmlSerializer          CurrencySerializer = new XmlSerializer(typeof(WonkaRefCurrency));
+
+            XmlNodeList CurrencyNodeList = moXmlDoc.GetElementsByTagName("WonkaRefCurrency");
+            foreach (XmlNode CurrencyNode in CurrencyNodeList)
+            {
+                WonkaRefCurrency TempCurrency = 
+                    (WonkaRefCurrency )CurrencySerializer.Deserialize(new StringReader(CurrencyNode.OuterXml));
+
+                CurrencyCache.Add(TempCurrency);
+            }
+
+            return CurrencyCache;
+        }
+
+        public List<WonkaRefField> GetFieldCache()
+        {
+            List<WonkaRefField> FieldCache      = new List<WonkaRefField>();
+            XmlSerializer       FieldSerializer = new XmlSerializer(typeof(WonkaRefField));
+
+            XmlNodeList FieldNodeList = moXmlDoc.GetElementsByTagName("Field");
+            foreach (XmlNode FieldNode in FieldNodeList)
+            {
+                WonkaRefField TempField = (WonkaRefField) FieldSerializer.Deserialize(new StringReader(FieldNode.OuterXml));
+
+                FieldCache.Add(TempField);
+            }
+
+            return FieldCache;
+        }
+
+        public List<WonkaRefGroup> GetGroupCache()
+        {
+            List<WonkaRefGroup> GroupCache      = new List<WonkaRefGroup>();
+            XmlSerializer       GroupSerializer = new XmlSerializer(typeof(WonkaRefGroup));
+
+            XmlNodeList GroupNodeList = moXmlDoc.GetElementsByTagName("Group");
+            foreach (XmlNode GroupNode in GroupNodeList)
+            {
+                WonkaRefGroup TempGroup = (WonkaRefGroup) GroupSerializer.Deserialize(new StringReader(GroupNode.OuterXml));
+
+                GroupCache.Add(TempGroup);
+            }
+
+            return GroupCache;
+        }
+
+        public List<WonkaRefSource> GetSourceCache()
+        {
+            List<WonkaRefSource> SourceCache      = new List<WonkaRefSource>();
+            XmlSerializer        SourceSerializer = new XmlSerializer(typeof(WonkaRefSource));
+
+            XmlNodeList SourceNodeList = moXmlDoc.GetElementsByTagName("WonkaRefSource");
+            foreach (XmlNode SourceNode in SourceNodeList)
+            {
+                WonkaRefSource TempSource = (WonkaRefSource) SourceSerializer.Deserialize(new StringReader(SourceNode.OuterXml));
+
+                SourceCache.Add(TempSource);
+            }
+
+            return SourceCache;
+        }
+
+        public List<WonkaRefSourceField> GetSourceFieldCache()
+        {
+            List<WonkaRefSourceField> SrcFldCache      = new List<WonkaRefSourceField>();
+            XmlSerializer             SrcFldSerializer = new XmlSerializer(typeof(WonkaRefSourceField));
+
+            XmlNodeList SrcFldNodeList = moXmlDoc.GetElementsByTagName("WonkaRefSourceField");
+            foreach (XmlNode SourceFieldNode in SrcFldNodeList)
+            {
+                WonkaRefSourceField TempSourceField = 
+                    (WonkaRefSourceField) SrcFldSerializer.Deserialize(new StringReader(SourceFieldNode.OuterXml));
+
+                SrcFldCache.Add(TempSourceField);
+            }
+
+            return SrcFldCache;
+        }
+
+        public List<WonkaRefStandard> GetStandardCache()
+        {
+            return new List<WonkaRefStandard>();
+        }
+
+        #endregion
+
+        #region Extended Metadata Cache
+
+        public List<WonkaRefAttrCollection> GetAttrCollectionCache()
+        {
+            return new List<WonkaRefAttrCollection>();
+        }
+
+        #endregion
+
+        #endregion
+    }
+}

--- a/WonkaSystem/WonkaRef/Extensions/WonkaRefDeserializeLocalSource.cs
+++ b/WonkaSystem/WonkaRef/Extensions/WonkaRefDeserializeLocalSource.cs
@@ -10,6 +10,12 @@ using WonkaRef;
 
 namespace WonkaRef.Extensions
 {
+    /// <summary>
+    /// 
+    /// This class will help instantiate the Ref environment (singleton) by parsing the serialized instance
+    /// from a previous session.
+    /// 
+    /// </summary>
     public class WonkaRefDeserializeLocalSource : IMetadataRetrievable
     {
         private string            msMetadataFileContents = null;
@@ -134,7 +140,19 @@ namespace WonkaRef.Extensions
 
         public List<WonkaRefStandard> GetStandardCache()
         {
-            return new List<WonkaRefStandard>();
+            List<WonkaRefStandard> StandardCache      = new List<WonkaRefStandard>();
+            XmlSerializer          StandardSerializer = new XmlSerializer(typeof(WonkaRefStandard));
+
+            XmlNodeList StdNodeList = moXmlDoc.GetElementsByTagName("WonkaRefStandard");
+            foreach (XmlNode StandardNode in StdNodeList)
+            {
+                WonkaRefStandard TempStandard = 
+                    (WonkaRefStandard) StandardSerializer.Deserialize(new StringReader(StandardNode.OuterXml));
+
+                StandardCache.Add(TempStandard);
+            }
+
+            return StandardCache;
         }
 
         #endregion
@@ -143,7 +161,19 @@ namespace WonkaRef.Extensions
 
         public List<WonkaRefAttrCollection> GetAttrCollectionCache()
         {
-            return new List<WonkaRefAttrCollection>();
+            List<WonkaRefAttrCollection> AttrCollCache      = new List<WonkaRefAttrCollection>();
+            XmlSerializer                AttrCollSerializer = new XmlSerializer(typeof(WonkaRefAttrCollection));
+
+            XmlNodeList AttrCollNodeList = moXmlDoc.GetElementsByTagName("AttrCollection");
+            foreach (XmlNode AttrCollNode in AttrCollNodeList)
+            {
+                WonkaRefAttrCollection TempAttrColl = 
+                    (WonkaRefAttrCollection) AttrCollSerializer.Deserialize(new StringReader(AttrCollNode.OuterXml));
+
+                AttrCollCache.Add(TempAttrColl);
+            }
+
+            return AttrCollCache;
         }
 
         #endregion

--- a/WonkaSystem/WonkaRef/Extensions/WonkaRefDummySource.cs
+++ b/WonkaSystem/WonkaRef/Extensions/WonkaRefDummySource.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+
+using WonkaRef;
+
+namespace WonkaRef.Extensions
+{
+    public class WonkaRefDummySource : IMetadataRetrievable
+    {
+        public WonkaRefDummySource()
+        { }
+
+        #region Required Interface Methods
+
+        #region Standard Metadata Cache (Minimum Set)
+
+        public List<WonkaRefAttr> GetAttrCache()
+        {
+            return new List<WonkaRefAttr>();
+        }
+
+        public List<WonkaRefCurrency> GetCurrencyCache()
+        {
+            return new List<WonkaRefCurrency>();
+        }
+
+        public List<WonkaRefField> GetFieldCache()
+        {
+            return new List<WonkaRefField>();
+        }
+
+        public List<WonkaRefGroup> GetGroupCache()
+        {
+            return new List<WonkaRefGroup>();
+        }
+
+        public List<WonkaRefSource> GetSourceCache()
+        {
+            return new List<WonkaRefSource>();
+        }
+
+        public List<WonkaRefSourceField> GetSourceFieldCache()
+        {
+            return new List<WonkaRefSourceField>();
+        }
+
+        public List<WonkaRefStandard> GetStandardCache()
+        {
+            return new List<WonkaRefStandard>();
+        }
+
+        #endregion
+
+        #region Extended Metadata Cache
+
+        public List<WonkaRefAttrCollection> GetAttrCollectionCache()
+        {
+            return new List<WonkaRefAttrCollection>();
+        }
+
+        #endregion
+
+        #endregion
+    }
+}

--- a/WonkaSystem/WonkaRef/Extensions/WonkaRefException.cs
+++ b/WonkaSystem/WonkaRef/Extensions/WonkaRefException.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace WonkaRef.Extensions
+{
+    /// <summary>
+    /// 
+    /// This exception should be used when encountering any issue with using
+    /// extensions regarding the WonkaRef library.
+    /// 
+    /// </summary>
+    public class WonkaRefException : Exception
+    {
+        public WonkaRefException(string psErrorMessage) : base(psErrorMessage)
+        { }
+    }
+}

--- a/WonkaSystem/WonkaRef/Extensions/WonkaRefExtensions.cs
+++ b/WonkaSystem/WonkaRef/Extensions/WonkaRefExtensions.cs
@@ -39,6 +39,25 @@ namespace WonkaRef.Extensions
 
         /// <summary>
         /// 
+        /// This method will deserialize the data domain of the WonkaRevEnvironment from a provided string.
+        /// 
+        /// <param name="poDataDomainPayload">The string payload that needs to be deserialized</param>
+        /// <returns>The WonkaRefEnvironment instantiated from the data domain file</returns>
+        /// </summary>
+        public static WonkaRefEnvironment DeserializeRefEnvFromStringPayload(this string psDataDomainPayload)
+        {
+            WonkaRefEnvironment RefEnv = null;
+
+            if (String.IsNullOrEmpty(psDataDomainPayload))
+                throw new WonkaRefException("ERROR!  Reference to data domain payload is invalid.");
+
+            RefEnv = WonkaRefEnvironment.CreateInstance(false, new WonkaRefDeserializeLocalSource(psDataDomainPayload));
+
+            return RefEnv;
+        }
+
+        /// <summary>
+        /// 
         /// This method will serialize the data domain of the WonkaRevEnvironment to a local file.
         /// 
         /// <param name="poRefEnv">The instance of the WonkaRefEnvironment which we wish to serialize</param>
@@ -67,14 +86,15 @@ namespace WonkaRef.Extensions
         /// This method will serialize the data domain of the WonkaRefEnvironment to IPFS.
         /// 
         /// <param name="poRefEnv">The instance of the WonkaRefEnvironment which we wish to serialize</param>
+        /// <param name="psPeerKey">The IPFS node that belongs to the caller</param>
         /// <param name="psFileName">The file name where the data should be serialized to</param>
         /// <returns>Indicates whether or not the serialization was successful</returns>
         /// </summary>
-        public static bool SerializeToIPFS(this WonkaRefEnvironment poRefEnv, string psFileName)
+        public static bool SerializeToIPFS(this WonkaRefEnvironment poRefEnv, string psPeerKey, string psFileName)
         {
             bool bResult = true;
 
-            // NOTE: Do work here
+            // NOTE: Still undecided as to whether or not this function should be here
 
             return bResult;
         }
@@ -105,4 +125,3 @@ namespace WonkaRef.Extensions
     }
 
 }
-

--- a/WonkaSystem/WonkaRef/Extensions/WonkaRefExtensions.cs
+++ b/WonkaSystem/WonkaRef/Extensions/WonkaRefExtensions.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace WonkaRef.Extensions
+{
+    /// <summary>
+    /// 
+    /// This extensions class provides the functionality to serialize/deserialize the data domain (i.e., WonkaRef data)
+    /// with respect to a local file or an IPFS file.
+    /// 
+    /// </summary>
+    public static class WonkaRefExtensions
+    {
+        /// <summary>
+        /// 
+        /// This method will serialize the data domain of the WonkaRevEnvironment to a local file.
+        /// 
+        /// <param name="poRefEnv">The instance of the WonkaRefEnvironment which we wish to serialize</param>
+        /// <returns>Indicates whether or not the serialization was successful</returns>
+        /// </summary>
+        public static bool SerializeToLocalFile(this WonkaRefEnvironment poRefEnv)
+        {
+            bool bResult = true;
+
+            // NOTE: Do work here
+
+            return bResult;
+        }
+
+        /// <summary>
+        /// 
+        /// This method will serialize the data domain of the WonkaRefEnvironment to IPFS.
+        /// 
+        /// <param name="poRefEnv">The instance of the WonkaRefEnvironment which we wish to serialize</param>
+        /// <returns>Indicates whether or not the serialization was successful</returns>
+        /// </summary>
+        public static bool SerializeToIPFS(this WonkaRefEnvironment poRefEnv)
+        {
+            bool bResult = true;
+
+            // NOTE: Do work here
+
+            return bResult;
+        }
+
+    }
+
+}
+

--- a/WonkaSystem/WonkaRef/WonkaRef.csproj
+++ b/WonkaSystem/WonkaRef/WonkaRef.csproj
@@ -62,6 +62,7 @@
     <Compile Include="Extensions\WonkaRefExtensions.cs" />
     <Compile Include="Extensions\WonkaRefException.cs" />
     <Compile Include="Extensions\WonkaRefDummySource.cs" />
+    <Compile Include="Extensions\WonkaRefDeserializeLocalSource.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Extensions\" />

--- a/WonkaSystem/WonkaRef/WonkaRef.csproj
+++ b/WonkaSystem/WonkaRef/WonkaRef.csproj
@@ -60,6 +60,7 @@
     <Compile Include="WonkaRefSourceField.cs" />
     <Compile Include="WonkaRefStandard.cs" />
     <Compile Include="Extensions\WonkaRefExtensions.cs" />
+    <Compile Include="Extensions\WonkaRefException.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Extensions\" />

--- a/WonkaSystem/WonkaRef/WonkaRef.csproj
+++ b/WonkaSystem/WonkaRef/WonkaRef.csproj
@@ -59,6 +59,10 @@
     <Compile Include="WonkaRefSource.cs" />
     <Compile Include="WonkaRefSourceField.cs" />
     <Compile Include="WonkaRefStandard.cs" />
+    <Compile Include="Extensions\WonkaRefExtensions.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Extensions\" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/WonkaSystem/WonkaRef/WonkaRef.csproj
+++ b/WonkaSystem/WonkaRef/WonkaRef.csproj
@@ -61,6 +61,7 @@
     <Compile Include="WonkaRefStandard.cs" />
     <Compile Include="Extensions\WonkaRefExtensions.cs" />
     <Compile Include="Extensions\WonkaRefException.cs" />
+    <Compile Include="Extensions\WonkaRefDummySource.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Extensions\" />

--- a/WonkaSystem/WonkaRef/WonkaRefEnvironment.cs
+++ b/WonkaSystem/WonkaRef/WonkaRefEnvironment.cs
@@ -17,6 +17,10 @@ namespace WonkaRef
         private static object              mLock     = new object();
         private static WonkaRefEnvironment mInstance = null;
 
+        // NOTE: This constructor is necessary for serialization/deserialization purposes
+        private WonkaRefEnvironment()
+        { }
+
         private WonkaRefEnvironment(bool bAllMetadata, IMetadataRetrievable pMetadataRetrievable)
         {
             DebugLevel = 1;

--- a/WonkaSystem/WonkaRef/WonkaRefEnvironment.cs
+++ b/WonkaSystem/WonkaRef/WonkaRefEnvironment.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Serialization;
+using System.Xml.Serialization;
 
 namespace WonkaRef
 {
@@ -296,7 +297,8 @@ namespace WonkaRef
         #region Standard Metadata Cache (Minimum Set)
 
         public List<WonkaRefAttr>             AttrCache { get; }
-        
+
+        [XmlIgnore]
         public List<WonkaRefAttr>             AttrKeys { get; }
 
         private Dictionary<int, WonkaRefAttr> AttrMap { get; }


### PR DESCRIPTION
This branch provides the functionality to:

1.) Serialize metadata needed by the rules engine.
2.) Deserialize metadata needed by the rules engine.
3.) Ingest the schema classes created by Entity Framework, so that they may be converted into metadata (especially the data domain) needed by the rules engine.
4.) Create a sample rules file for the user, based on an instance of the WonkaRefEnvironment (i.e., the metadata).